### PR TITLE
- Fix a typo? on src/finiteVolume/Make/files: timeVaryingMappedFluctu…

### DIFF
--- a/applications/solvers/incompressible/windEnergy/pisoFoamTurbine.ALMAdvancedFASTv8/2.3-and-higher/options
+++ b/applications/solvers/incompressible/windEnergy/pisoFoamTurbine.ALMAdvancedFASTv8/2.3-and-higher/options
@@ -12,7 +12,8 @@ EXE_INC = \
     -I$(WM_PROJECT_USER_DIR)/src/turbineModels/turbineModelsFASTv8/lnInclude \
     $(PFLAGS) \
     $(PINC) \
-    -I$(FAST_DIR)/include
+    -I$(FAST_DIR)/include \
+    -I$(HDF5_DIR)/include 
 
 
 EXE_LIBS = \

--- a/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedFASTv8/2.3-and-higher/options
+++ b/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedFASTv8/2.3-and-higher/options
@@ -14,6 +14,7 @@ EXE_INC = \
     $(PFLAGS) \
     $(PINC) \
     -I$(FAST_DIR)/include \
+    -I$(HDF5_DIR)/include \
     -I./interpolate2D
 
 
@@ -25,6 +26,7 @@ EXE_LIBS = \
     -lincompressibleLESModels \
     -luserTurbineModelsFASTv8 \
     -lfiniteVolume \
+    -luserfiniteVolume \
     -lmeshTools \
     -lfvOptions \
     -lsampling \

--- a/src/finiteVolume/Make/files
+++ b/src/finiteVolume/Make/files
@@ -9,7 +9,7 @@ $(derivedFvPatchFields)/turbulentABLTemperatureControlled/turbulentABLTemperatur
 $(derivedFvPatchFields)/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchFields.C
 
 /* TimeVaryingMappedFixedValue with organized random perturbations */
-$(derivedFvPatchFields)/timeVaryingMappedFluctuatingFixedValue/timeVaryingMappedFluctuatingFixedValue.C
+$(derivedFvPatchFields)/timeVaryingMappedFluctuatingFixedValue/timeVaryingMappedFluctuatingFixedValueFvPatchFields.C
 
 /* Surface Shear Stress Models */
 surfaceStressModels = $(derivedFvPatchFields)/surfaceStressModels

--- a/src/turbineModels/turbineModelsFASTv8/Make/options
+++ b/src/turbineModels/turbineModelsFASTv8/Make/options
@@ -11,7 +11,8 @@ EXE_INC = \
     -I$(LIB_SRC)/transportModels \
     $(PFLAGS) \
     $(PINC) \
-    -I$(FAST_DIR)/include
+    -I$(FAST_DIR)/include \
+    -I$(HDF5_DIR)/include 
 
 LIB_LIBS = \
     -ltriSurface \


### PR DESCRIPTION
- Fix a typo? on src/finiteVolume/Make/files timeVaryingMappedFluctuatingFixedValue.C does not exist, but timeVaryingMappedFluctuatingFixedValueFvPatchFields.C does.

- Add library libuserfiniteVolume as a dependency to windPlantSolver.ALMAdvancedFASTv8/2.3-and-higher/options
- Add extra paths to HDF5 includes